### PR TITLE
Fix environment data access API not being replaced with production values

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -69,6 +69,10 @@
                 {
                   "replace": "src/environments/data-api.environment.ts",
                   "with": "src/environments/data-api.environment.prod.ts"
+                },
+                {
+                  "replace": "src/environments/data-access-api.environment.ts",
+                  "with": "src/environments/data-access-api.environment.prod.ts"
                 }
               ],
               "optimization": true,


### PR DESCRIPTION
A missing fileReplacements entry was added. When launching a production build, the data access api file will be replaced as originally intended.